### PR TITLE
Fix installscript

### DIFF
--- a/bin/otrverwaltung
+++ b/bin/otrverwaltung
@@ -34,7 +34,6 @@ except ImportError:
 
 try:
     import gi
-
     gi.require_version('Gtk', '3.0')
     from gi.repository import Gtk, GdkPixbuf, Gdk, GObject
 
@@ -699,17 +698,8 @@ class App:
 
         cmd_exists = lambda x: any(
             os.access(os.path.join(pathx, x), os.X_OK) for pathx in os.environ["PATH"].split(os.pathsep))
-        
-        if cmd_exists('mpv'):
-            if self.config.get('general', 'mplayer_fullscreen'):
-                p = subprocess.Popen(
-                    [self.config.get_program('mpv'), "-fs", "-geometry", "50%:50%", "-sub-file",
-                     f_mpv_sub, f_mpv_edl])
-            else:
-                 p = subprocess.Popen(
-                    [self.config.get_program('mpv'), "-geometry", "50%:50%", "-sub-file", f_mpv_sub,
-                     f_mpv_edl])
-        elif cmd_exists('mplayer'):
+
+        if cmd_exists('mplayer'):
             if self.config.get('general', 'mplayer_fullscreen'):
                 p = subprocess.Popen(
                     [self.config.get_program('mplayer'), "-fs", "-zoom", "-geometry", "50%:50%", "-osdlevel", "3",
@@ -718,6 +708,15 @@ class App:
                 p = subprocess.Popen(
                     [self.config.get_program('mplayer'), "-geometry", "50%:50%", "-osdlevel", "3", "-edl", f_edl,
                      "-sub", f_sub, video_filename])
+        elif cmd_exists('mpv'):
+            if self.config.get('general', 'mplayer_fullscreen'):
+                p = subprocess.Popen(
+                    [self.config.get_program('mpv'), "-fs", "-geometry", "50%:50%", "-sub-file",
+                     f_mpv_sub, f_mpv_edl])
+            else:
+                 p = subprocess.Popen(
+                    [self.config.get_program('mpv'), "-geometry", "50%:50%", "-sub-file", f_mpv_sub,
+                     f_mpv_edl])
         else:
             self.__gui.message_error_box("Weder mpv noch mplayer sind zum Anzeigen der Schnitte installiert.")
             return

--- a/installscripts/otrv3p-install-deb.sh
+++ b/installscripts/otrv3p-install-deb.sh
@@ -62,6 +62,7 @@ install_deps () {
                         gir1.2-gstreamer-1.0 \
                         python3-simplejson \
                         python3-libtorrent \
+                        python3-gi-cairo \
                         python3-cairo \
                         python3-crypto \
                         python3-requests \


### PR DESCRIPTION
- otrverwaltung:__show: (Schnitte anspielen) if mplayer is installed it will be used
  before mpv (original behavior)
- otrv3p-install-deb.sh: add missing dependency python3-gi-cairo