### PR TITLE
Hotfix for wrong icon path

### DIFF
--- a/otrverwaltung/gui/gui.py
+++ b/otrverwaltung/gui/gui.py
@@ -51,7 +51,7 @@ class Gui:
         self.dialog_plugins = PluginsDialog.NewPluginsDialog(self)
 
         for window in [self.main_window]:
-            window.set_icon(GdkPixbuf.Pixbuf.new_from_file(path.get_image_path('icon3.png')))
+            window.set_icon(GdkPixbuf.Pixbuf.new_from_file(path.get_image_path('icon.png')))
 
     def run(self):
         Gtk.main()


### PR DESCRIPTION
Icon now loaded from symlink 'icon.png'