### PR TITLE
Fixed naming of Temp files for more than 5 cuts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,13 @@
 n.n,
-    * Cutinterface: Neues Feature "seeker".
-    * Down-/Upload von Schnittlisten funktioniert mit der neuen Seite cutlist.at
+    * Cutinterface: Widgets skalieren mit Fenstergröße
+    * Cutinterface: Neues Feature "Sucher (seeker)"
+    * Down-/Upload von Schnittlisten funktioniert mit der neuen cutlist.at (sniplist)
     * Neue Option: 'mpv bevorzugen' für 'Schnitte anspielen'
     * Die Funktion Zugangsdaten prüfen zeigt das Ergbnis jetzt deutlich an.
     * Keyframe jump funktioniert jetzt auch für Ubuntu etc.
     * Neues Icon
     * setup.py funktioniert nun.
-    * Der open source Dekoder otrtool kann verwendet werden.
+    * Der opensource Dekoder otrtool kann verwendet werden.
     * Bugfixes
 
 3.2.1-A, 2018-04-27
@@ -33,8 +34,8 @@ n.n,
 ________________________________________________________________________________________________________________________________
 
 0.9.7, 30. Mai. 16:
-    * Plugin ConvertToMP3 hinzugfügt (Danke beli3ver)
-    * Icon für "In den Müll verschieben" geändert
+    * Plugin ConvertToMP3 hinzugfügt. Danke beli3ver).
+    * Icon für "In den Müll verschieben" geändert.
 
 0.9.1, 10. Sept. 10:
     * HQ-Dateinamen werden beim Download korrekt angezeigt.
@@ -44,7 +45,8 @@ ________________________________________________________________________________
 0.9, 26. Mai 10:
     * Downloadmöglichkeit
     * Abhängigkeiten wie mplayer, wget usw. sind im deb-Paket vorhanden.
-    * Der Zusammenfassungsdialog wird nicht mehr automatisch angezeigt, sondern es wird ein Hinweis in der Leiste eingeblendet.
+    * Der Zusammenfassungsdialog wird nicht mehr automatisch angezeigt,
+      sondern es wird ein Hinweis in der Leiste eingeblendet.
 
 0.8.4, 17. April 10:
     * Bugfix: http://www.otrforum.com/showthread.php/59666, Danke @Artemis1121

--- a/README.md
+++ b/README.md
@@ -1,88 +1,13 @@
-OTR-Verwaltung
-==============
+# OTR-Verwaltung3Plus
+### Deutsch
+Eine Portierung der [OTR-Verwaltung++](https://github.com/monarc99/otr-verwaltung) zu python3 und gstreamer1.0.
 
-Copyright (C) 2010 Benjamin Elbers <elbersb@gmail.com>
+Feedback, Bugreport, Fehler: [Thread im otrforum.com](https://www.otrforum.com/showthread.php?74447-OTRVerwaltung3Plus-eine-Portierung-von-OTRVerwaltung-hinzu-Python3-und-Gtk3&goto=newpost).
 
-Die Ursprungsversion von OTRVerwaltung wurden von Benjamin Elbers programmiert.
+#### [Wiki für mehr Informationen](https://github.com/EinApfelBaum/otr-verwaltung3p/wiki/Home).
 
-OTR-Verwaltung++
------
+### English
+A port of [OTR-Verwaltung++](https://github.com/monarc99/otr-verwaltung) to python3 und gstreamer1.0.
 
-OTRVerwaltung wurde durch einige Patches erweitert, daraus entstand OTRVerwaltung++
-https://github.com/monarc99/otr-verwaltung
-
-OTR-Verwaltung3Plus
------
-
-Ein Port zu Python 3 und GTK3+.
-
-https://github.com/EinApfelBaum/otr-verwaltung/tree/python3/GTK3
-
-Feedback, Bugreport, Fehler
-
-http://www.otrforum.com/showthread.php?74447-OTRVerwaltung3Plus-eine-Portierung-von-OTRVerwaltung-hinzu-Python3-und-Gtk3
-
-__Alpha Version__
-
-Ich weise hier auch noch mal darauf hin, dass dies noch keine Release Version ist.
-
-
-In einer VM Ubuntu 16.04 und Linux Mint 18.1 musste ich folgende Pakete installieren:
-
-`sudo apt-get install python3-libtorrent mediainfo-gui mpv python3-pip`
-
-`pip3 install pycrypto gitpython`
-
-Pakete, welche notwendig sind, vielleicht aber schon installiert sind:
-
-`sudo apt-get install python3-xdg python3-gst-1.0 gir1.2-gstreamer-1.0 gstreamer1.0-libav:amd64 gstreamer1.0-nice:amd64 gstreamer1.0-plugins-base:amd64 gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-good:amd64 gstreamer1.0-tools libgstreamer-plugins-base1.0-0:amd64 libgstreamer-plugins-good1.0-0:amd64 libgstreamer1.0-0:amd64 libgstreamer1.0-dev`
-
-OTRVerwaltung starten:
-`python3 /home/USER/OTRVerwaltung/bin/otrverwaltung`
-
-__Anmerkung:__
-
-Bei mir (Linux Mint 18.1 Cinnamon) wird der CutInterfaceDialog nicht richtig angezeigt.
-Das Video ist nicht zu sehen, aber Audio kann ich hören.
-In den VMs tritt dieser Fehler nicht auf. Dort wird Bild und Video richtig im CutInterfaceDialog verarbeitet.
-Die Ursache habe ich bei mir noch nicht gefunden.
-
-TODO
-----
-
-__Oberfläche__
-- Windows
-- [x] MainWindow
-- [x] PreferencesWindow
-- Dialoge
-- [x] AddDownloadDialog
-- [x] ArchiveDialog
-- [x] ConclusionDialog
-- [x] CutDialog
-- [ ] CutinterfaceDialog
-- [ ] DownloadPropertiesDialog
-- [x] EmailPasswordDialog
-- [x] LoadCutDialog
-- [x] PlanningDialog
-- [x] PluginsDialog
-- [x] RenameDialog
-
-__Funktionalität__
-- [x] Datei löschen, wiederherstellen
-- [x] Datei Abspielen (PlugIn)
-- [x] MediaInfo (PlugIn)
-- [x] Archivieren
-- [x] Convert to MKV
-- [x] Datei umbennen
-- [x] Ordner erstellen
-- [x] Ordner löschen
-- [ ] Download
-- [ ] geplante Sendungen
-- [x] Decode otrkey Datei
-- [x] Cut Avi - SmartMKVMerge
-- [x] Cut HD - SmartMKVMerge
-- [ ] Cut mp4
-
-__Feinheiten__
-- [ ] Oberflächengestaltung anpassen ( Abstände , Ränder, etc. ... )
-- [ ] Code cleanup
+Feedback, Bugreport, Fehler: [Thread in otrforum.com](https://www.otrforum.com/showthread.php?74447-OTRVerwaltung3Plus-eine-Portierung-von-OTRVerwaltung-hinzu-Python3-und-Gtk3&goto=newpost).
+#### [See the wiki for more information](https://github.com/EinApfelBaum/otr-verwaltung3p/wiki/EN_Home)

--- a/bin/otrverwaltung
+++ b/bin/otrverwaltung
@@ -183,7 +183,8 @@ class App:
                 'x264vfw_hq_string': '--tune film --direct auto --force-cfr --rc-lookahead 60 --b-adapt 2 --aq-mode 2 --weightp 0',
                 'x264vfw_mp4_string': '--force-cfr --profile baseline --preset medium --trellis 0',
                 'pre_cut_show': 10,
-                'after_cut_show': 10
+                'after_cut_show': 10,
+                'alt_time_frame_conv': False
             },
             'downloader': {
                 'resume_on_startup': True,

--- a/data/ui/ConclusionDialog.glade
+++ b/data/ui/ConclusionDialog.glade
@@ -43,13 +43,13 @@
         <col id="0" translatable="yes">2 - Anfang und Ende halbwegs genau geschnitten</col>
       </row>
       <row>
-        <col id="0" translatable="yes">3 - Schnitte annehmbar, Werbung nicht entfernt</col>
+        <col id="0" translatable="yes">3 - Schnitte annehmbar, Werbung wurde entfernt</col>
       </row>
       <row>
         <col id="0" translatable="yes">4 - doppelte Szenen wurden nicht entfernt oder es sind schönere Schnitte möglich</col>
       </row>
       <row>
-        <col id="0" translatable="yes">5 - unerwünschtes Material framegenau entfernt</col>
+        <col id="0" translatable="yes">5 - Sämtliches unerwünschtes Material framegenau entfernt</col>
       </row>
     </data>
   </object>

--- a/data/ui/CutinterfaceDialog.glade
+++ b/data/ui/CutinterfaceDialog.glade
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk+" version="3.20"/>
   <requires lib="CutinterfaceDialog" version="1.0"/>
-  <!-- interface-local-resource-path ../media -->
   <object class="GtkListStore" id="cutslist">
     <columns>
       <!-- column-name Start -->
@@ -12,57 +11,89 @@
       <column type="gint"/>
     </columns>
   </object>
-  <object class="GtkImage" id="image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-ok</property>
-  </object>
   <object class="CutinterfaceDialog" id="cutinterface_dialog">
     <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">normal</property>
+    <property name="type_hint">dialog</property>
     <signal name="key-press-event" handler="on_window_key_press_event" swapped="no"/>
     <signal name="key-release-event" handler="on_window_key_release_event" swapped="no"/>
     <child>
       <placeholder/>
     </child>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox">
-        <property name="visible">True</property>
+      <object class="GtkBox" id="vbox_top">
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area">
-            <property name="visible">True</property>
+          <object class="GtkButtonBox" id="bboxintern">
             <property name="can_focus">False</property>
+            <property name="margin_top">10</property>
+            <property name="margin_bottom">10</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">Abbrechen</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="button_ok">
-                <property name="label">Schneiden</property>
+                <property name="label" translatable="yes">Schneiden</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="image">image</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="hbox_label_filename_undo">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="label_filename">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">10</property>
+                <property name="label" translatable="yes">Datei: </property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_undo">
+                <property name="label" translatable="yes">Undo</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="margin_right">10</property>
+                <signal name="clicked" handler="on_button_undo_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -70,39 +101,128 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkGrid" id="grid1">
+          <object class="GtkBox" id="hbox01">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_top">5</property>
             <child>
-              <object class="GtkBox" id="hbox7">
+              <object class="GtkBox" id="vbox_movie_window">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel" id="label_filename">
+                  <object class="GtkDrawingArea" id="movie_window">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Aktuelle Datei: </property>
-                    <property name="xalign">0</property>
+                    <property name="margin_left">10</property>
+                    <property name="margin_right">10</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <signal name="draw" handler="on_draw_movie_window" swapped="no"/>
+                    <signal name="realize" handler="on_realize" swapped="no"/>
+                    <signal name="unrealize" handler="on_unrealize" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="button_undo">
-                    <property name="label">gtk-undo</property>
+                  <object class="GtkButtonBox" id="bbox01">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="on_button_undo_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="margin_top">5</property>
+                    <property name="layout_style">center</property>
+                    <child>
+                      <object class="GtkButton" id="button_play">
+                        <property name="label" translatable="yes"> Play </property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="clicked" handler="on_button_play_pause_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_a">
+                        <property name="label" translatable="yes">A  [</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="margin_left">20</property>
+                        <property name="margin_right">2</property>
+                        <signal name="clicked" handler="on_button_a_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_b">
+                        <property name="label" translatable="yes">]  B</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="margin_right">2</property>
+                        <signal name="clicked" handler="on_button_b_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_remove">
+                        <property name="label" translatable="yes">Entfernen</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">baseline</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="clicked" handler="on_button_remove_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="checkbutton_hide_cuts">
+                        <property name="label" translatable="yes">Ausblenden</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="margin_left">10</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_checkbutton_hide_cuts_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -110,302 +230,157 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox6">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="hbox8">
+                  <object class="GtkButtonBox" id="bbox02">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="margin_left">10</property>
+                    <property name="margin_right">10</property>
+                    <property name="margin_top">5</property>
+                    <property name="margin_bottom">10</property>
+                    <property name="spacing">2</property>
+                    <property name="layout_style">center</property>
                     <child>
-                      <object class="GtkBox" id="vbox7">
+                      <object class="GtkButton" id="button_keyfast_back">
+                        <property name="label" translatable="yes">&lt;&lt; Key</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox" id="hbox9">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">5</property>
-                            <child>
-                              <object class="GtkButton" id="button_play">
-                                <property name="label">gtk-media-play</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
-                                <signal name="clicked" handler="on_button_play_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_pause">
-                                <property name="label">gtk-media-pause</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
-                                <signal name="clicked" handler="on_button_pause_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator" id="vseparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="padding">11</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_a">
-                                <property name="label" translatable="yes">Marker A [</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_a_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_b">
-                                <property name="label" translatable="yes">] Marker B</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_b_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_remove">
-                                <property name="label" translatable="yes">Bereich entfernen</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_remove_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="hbox10">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkButton" id="button_keyfast_back">
-                                <property name="label" translatable="yes">&lt;&lt; Key</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_keyfast_back_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_ffast_back">
-                                <property name="label" translatable="yes">&lt;&lt; 100</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_ffast_back_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_fast_back">
-                                <property name="label" translatable="yes">&lt;&lt; 10</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_fast_back_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_back">
-                                <property name="label" translatable="yes">&lt; Frame</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_back_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_forward">
-                                <property name="label" translatable="yes">Frame &gt;</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_forward_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_fast_forward">
-                                <property name="label" translatable="yes">10 &gt;&gt;</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_fast_forward_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_ffast_forward">
-                                <property name="label" translatable="yes">100 &gt;&gt;</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_ffast_forward_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">6</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_keyfast_forward">
-                                <property name="label" translatable="yes">Key &gt;&gt;</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_button_keyfast_forward_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">7</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_keyfast_back_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">0</property>
+                        <property name="non_homogeneous">True</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="vbox8">
+                      <object class="GtkButton" id="button_ffast_back">
+                        <property name="label" translatable="yes">&lt;&lt; 100</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkButton" id="load_button">
-                            <property name="label" translatable="yes">Lade Cutlist</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <signal name="clicked" handler="on_load_button_clicked" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_ffast_back_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_fast_back">
+                        <property name="label" translatable="yes">&lt;&lt; 10</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_fast_back_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_back">
+                        <property name="label" translatable="yes">&lt; Frame</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_back_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_forward">
+                        <property name="label" translatable="yes">Frame &gt;</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_forward_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_fast_forward">
+                        <property name="label" translatable="yes">10 &gt;&gt;</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_fast_forward_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_ffast_forward">
+                        <property name="label" translatable="yes">100 &gt;&gt;</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_ffast_forward_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_keyfast_forward">
+                        <property name="label" translatable="yes">Key &gt;&gt;</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_button_keyfast_forward_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">7</property>
+                        <property name="non_homogeneous">True</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkEventBox" id="eventbox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="margin_left">10</property>
+                    <property name="margin_right">10</property>
                     <child>
                       <object class="GtkScale" id="slider">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="show_fill_level">True</property>
-                        <property name="restrict_to_fill_level">False</property>
-                        <property name="fill_level">0</property>
-                        <property name="draw_value">False</property>
+                        <property name="round_digits">0</property>
+                        <property name="digits">0</property>
+                        <property name="has_origin">False</property>
                         <signal name="draw" handler="on_slider_draw_event" swapped="no"/>
-                        <signal name="key-press-event" handler="on_slider_key_press_event" swapped="no"/>
                         <signal name="value-changed" handler="on_slider_value_changed" swapped="no"/>
                       </object>
                     </child>
@@ -413,19 +388,26 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="hbox11">
+                  <object class="GtkBox" id="hbox02">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="margin_left">10</property>
+                    <property name="margin_right">20</property>
+                    <property name="margin_top">10</property>
                     <child>
                       <object class="GtkLabel" id="label_time">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Frame: 0/0, Zeit 0s/0s</property>
+                        <property name="track_visited_links">False</property>
                         <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="gravity" value="west"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -434,14 +416,15 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox12">
+                      <object class="GtkBox" id="hbox03">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">5</property>
                         <child>
-                          <object class="GtkLabel" id="label3">
+                          <object class="GtkLabel" id="label_a">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="margin_left">10</property>
                             <property name="label" translatable="yes">Marker A:</property>
                           </object>
                           <packing>
@@ -465,10 +448,9 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSeparator" id="vseparator4">
+                          <object class="GtkSeparator" id="separator">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -477,7 +459,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="label4">
+                          <object class="GtkLabel" id="label_b">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Marker B:</property>
@@ -506,7 +488,6 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="pack_type">end</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -514,66 +495,30 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkDrawingArea" id="movie_window">
+              <object class="GtkBox" id="vbox_cutsview">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="double_buffered">False</property>
-                <signal name="draw" handler="on_draw_movie_window" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="checkbutton_hide_cuts">
-                <property name="label" translatable="yes">Geschnittene Szenen ausblenden</property>
-                <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-                <signal name="toggled" handler="on_checkbutton_hide_cuts_toggled" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox5">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="margin_left">10</property>
+                <property name="margin_right">10</property>
                 <property name="orientation">vertical</property>
-                <child>
-                  <object class="GtkLabel" id="label_cutlist">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Cuts:</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_bottom">5</property>
+                    <property name="shadow_type">in</property>
+                    <property name="propagate_natural_width">True</property>
                     <child>
                       <object class="GtkTreeView" id="cutsview">
                         <property name="visible">True</property>
@@ -587,8 +532,12 @@
                         <child>
                           <object class="GtkTreeViewColumn" id="cutsviewcolumn_start">
                             <property name="title" translatable="yes">Start</property>
+                            <property name="expand">True</property>
+                            <property name="alignment">1</property>
                             <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext_start"/>
+                              <object class="GtkCellRendererText" id="cellrenderertext_start">
+                                <property name="xalign">1</property>
+                              </object>
                               <attributes>
                                 <attribute name="text">0</attribute>
                               </attributes>
@@ -598,8 +547,12 @@
                         <child>
                           <object class="GtkTreeViewColumn" id="cutsviewcolumn_ende">
                             <property name="title" translatable="yes">Ende</property>
+                            <property name="expand">True</property>
+                            <property name="alignment">1</property>
                             <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext_ende"/>
+                              <object class="GtkCellRendererText" id="cellrenderertext_ende">
+                                <property name="xalign">1</property>
+                              </object>
                               <attributes>
                                 <attribute name="text">1</attribute>
                               </attributes>
@@ -612,14 +565,17 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButtonBox" id="vbuttonbox">
+                  <object class="GtkButtonBox" id="bbox03">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="margin_top">5</property>
+                    <property name="margin_bottom">12</property>
                     <property name="orientation">vertical</property>
+                    <property name="spacing">2</property>
                     <property name="layout_style">start</property>
                     <child>
                       <object class="GtkButton" id="button_delete_cut">
@@ -631,7 +587,7 @@
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
@@ -645,31 +601,58 @@
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButtonBox" id="bbox04">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="layout_style">center</property>
+                    <child>
+                      <object class="GtkButton" id="load_button">
+                        <property name="label" translatable="yes">Lade Cutlist</property>
+                        <property name="height_request">73</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_load_button_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/data/ui/PreferencesWindow.glade
+++ b/data/ui/PreferencesWindow.glade
@@ -1684,6 +1684,42 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel" id="labelForSpacing2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="lbl_time_frame">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Alternative Zeit -&gt; Frame Umwandlung:</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="check_alt_time_frame_conv">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <placeholder/>
                     </child>
                   </object>

--- a/otrverwaltung/actions/cutsmartmkvmerge.py
+++ b/otrverwaltung/actions/cutsmartmkvmerge.py
@@ -121,7 +121,7 @@ class CutSmartMkvmerge(Cut):
         else:
             return None, "Format nicht unterstützt (Nur MP4 H264, HQ H264 und HD H264 sind möglich)."
 
-        self.log.debug(codec)
+        self.log.debug("Codec: {}".format(codec))
 
         if codec_core != 125:
             warning_msg = "Unbekannte Kodierung entdeckt. Diese Datei genau prüfen und notfalls mit intern-Virtualdub und Codec ffdshow schneiden."
@@ -146,7 +146,7 @@ class CutSmartMkvmerge(Cut):
             except Exception  as e:
                 flag_singlethread = self.config.get('smartmkvmerge', 'single_threaded')
 
-        self.log.debug(flag_singlethread)
+        self.log.debug("flag_singlethread: {}".format(flag_singlethread))
 
         # audio part 1 - cut audio 
         if ac3_file:
@@ -159,7 +159,7 @@ class CutSmartMkvmerge(Cut):
 
         command = [mkvmerge, '--ui-language', 'en_US', '-D', '--split', 'parts:' + audio_timecodes, '-o',
                    self.workingdir + '/audio_copy.mkv'] + audio_import_files
-        self.log.debug(command)
+        self.log.debug("Command: {}".format(command))
         try:
             blocking_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                                 universal_newlines=True, env=my_env)
@@ -173,7 +173,7 @@ class CutSmartMkvmerge(Cut):
         keyframes, error = self.get_keyframes_from_file(filename)
         if keyframes == None:
             return None, "Keyframes konnten nicht ausgelesen werden."
-        self.log.debug(keyframes)
+        # self.log.debug(keyframes)
 
         # video part 2 - simulate smart rendering process
         for frame_start, frames_duration in cutlist.cuts_frames:
@@ -182,7 +182,7 @@ class CutSmartMkvmerge(Cut):
                 videolist += result
             else:
                 return None, 'Cutlist oder zu schneidende Datei passen nicht zusammen oder sind fehlerhaft.'
-        self.log.debug(videolist)
+        self.log.debug("Videolist: {}".format(videolist))
 
         # video part 3 - encode small parts - smart rendering part (1/2) 
         for encode, start, duration, video_part_filename in videolist:
@@ -198,7 +198,7 @@ class CutSmartMkvmerge(Cut):
                 command[5:5] = codec
             else:
                 return None, "Keine unterstützte Render-Engine zum Kodieren eingestellt"
-            self.log.debug(command)
+            self.log.debug("Command: {}".format(command))
             if encode:
                 try:
                     non_blocking_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -217,7 +217,7 @@ class CutSmartMkvmerge(Cut):
         # video part 4 - cut the big parts out the file (keyframe accurate) - smart rendering part (2/2)
         command = [mkvmerge, '--ui-language', 'en_US', '-A', '--split', 'parts-frames:' + video_splitframes, '-o',
                    self.workingdir + '/video_copy.mkv', filename]
-        self.log.debug(command)
+        self.log.debug("Command: {}".format(command))
         try:
             non_blocking_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                                     universal_newlines=True, env=my_env)
@@ -289,7 +289,7 @@ class CutSmartMkvmerge(Cut):
             map.extend(audiocodec)
             map.extend(audiofilter)
             args[8:8] = map
-            self.log.debug(args)
+            self.log.debug("Args: {}".format(args))
             try:
                 non_blocking_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                                         universal_newlines=True)
@@ -329,7 +329,7 @@ class CutSmartMkvmerge(Cut):
             cut_video = os.path.splitext(self.generate_filename(filename, 1))[0] + ".mkv"
         command = [mkvmerge, '--engage', 'no_cue_duration', '--engage', 'no_cue_relative_position', '--ui-language',
                    'en_US', '-o', cut_video] + self.video_files + self.audio_files
-        self.log.debug(command)
+        self.log.debug("Command: {}".format(command))
         try:
             blocking_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                                 universal_newlines=True, env=my_env)
@@ -352,7 +352,7 @@ class CutSmartMkvmerge(Cut):
             with ChangeDir(self.workingdir):
                 command = ['wine', path.get_tools_path('intern-eac3to/eac3to.exe'), os.path.basename(cut_video),
                            '-demux', '-silence', '-keepDialnorm']
-                self.log.debug(command)
+                self.log.debug("Command: {}".format(command))
                 try:
                     blocking_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                                         universal_newlines=True)
@@ -400,7 +400,7 @@ class CutSmartMkvmerge(Cut):
                 args.append(cut_video)
 
                 # mux to mp4 (mp4box) 
-                self.log.debug(args)
+                self.log.debug("Args: {}".format(args))
                 try:
                     blocking_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                                         universal_newlines=True)

--- a/otrverwaltung/actions/decodeorcut.py
+++ b/otrverwaltung/actions/decodeorcut.py
@@ -404,6 +404,9 @@ class DecodeOrCut(Cut):
                 if os.path.isfile(file_conclusion.uncut_video + '.ffindex_track00.kf.txt'):
                     os.remove(file_conclusion.uncut_video + '.ffindex_track00.kf.txt')
 
+                if os.path.isfile(file_conclusion.uncut_video + '.ffindex_track00.tc.txt'):
+                    os.remove(file_conclusion.uncut_video + '.ffindex_track00.tc.txt')
+
         return True
 
     def cut_file_manually(self, filename):

--- a/otrverwaltung/gui/ConclusionDialog.py
+++ b/otrverwaltung/gui/ConclusionDialog.py
@@ -18,8 +18,8 @@ import gi
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Pango, Gdk
-import os.path
-import os
+# import os.path
+import os, re
 import logging
 
 from otrverwaltung.constants import Action, Status, Cut_action
@@ -207,22 +207,23 @@ class ConclusionDialog(Gtk.Dialog, Gtk.Buildable):
             self.builder.get_object('box_rename').props.visible = cut_ok
 
             if cut_ok:
-                rename_list = []
+                re_fname = re.compile(".*?\.[0-9]{2}\.[a-zA-Z0-9_-]*")
+                if self.file_conclusion.cut.cutlist.filename and \
+                            (self.file_conclusion.cut.cutlist.filename != \
+                            re_fname.match(os.path.basename(self.file_conclusion.uncut_video)).group()):
+                        rename_list = [self.file_conclusion.cut.cutlist.filename]  # SuggestedMovieName
+                        rename_label = self.builder.get_object('label5')
+                        ## set background of label 'Umbenennen' to yellow to indicate there is
+                        ## a suggested filename in cutlist. Set font color to black
+                        rename_label.override_background_color(Gtk.StateType.NORMAL, Gdk.RGBA(100, 100,
+                                                                                                0, 0.8))
+                        rename_label.override_color(Gtk.StateType.NORMAL, Gdk.RGBA(0, 0, 0, 1.0))
+                else:
+                    rename_list = []
 
-                # reversed the order of rename entries and set_active last list entry later
                 rename_list.append(os.path.basename(self.file_conclusion.cut_video))
                 rename_list.append(self.rename_by_schema(os.path.basename(
                                                                 self.file_conclusion.cut_video)))
-
-                if self.file_conclusion.cut.cutlist.filename:
-                    rename_list.append(self.file_conclusion.cut.cutlist.filename)
-                    rename_label = self.builder.get_object('label5')
-                    ## gcurse   set background of label 'Umbenennen' to yellow to indicate there is
-                    ##          a suggested filename in cutlist. Set font color to black
-                    rename_label.override_background_color(Gtk.StateType.NORMAL, Gdk.RGBA(100, 100,
-                                                                                            0, 0.8))
-                    rename_label.override_color(Gtk.StateType.NORMAL, Gdk.RGBA(0, 0, 0, 1.0))
-
                 if not self.file_conclusion.cut.rename == "" \
                                         and not self.file_conclusion.cut.rename in rename_list:
                     rename_list.append(self.file_conclusion.cut.rename)
@@ -231,7 +232,8 @@ class ConclusionDialog(Gtk.Dialog, Gtk.Buildable):
                 self.gui.set_model_from_list(self.builder.get_object(
                                                         'comboboxentry_rename'), rename_list)
                 # set last entry of list active
-                self.builder.get_object('comboboxentry_rename').set_active(len(rename_list)-1)
+                # self.builder.get_object('comboboxentry_rename').set_active(len(rename_list)-1)
+                self.builder.get_object('comboboxentry_rename').set_active(0)
 
                 archive_to = self.file_conclusion.cut.archive_to
                 if not archive_to:

--- a/otrverwaltung/gui/CutinterfaceDialog.py
+++ b/otrverwaltung/gui/CutinterfaceDialog.py
@@ -15,16 +15,17 @@ from gi.repository import Gtk, Gdk, GObject, Gst, GstPbutils
 import logging
 
 # Needed for window.get_xid(), xvimagesink.set_window_handle(), respectively:
-from gi.repository import GdkX11, GstVideo
+# from gi.repository import GdkX11, GstVideo
 
-Gdk.threads_init()
+GObject.threads_init()
 Gst.init(None)
 
 import os
 import time
+#import inspect
 #from otrverwaltung.elements import KeySeekElement
 #from otrverwaltung.elements import DecoderWrapper
-from otrverwaltung import path
+from otrverwaltung import path as otrpath
 from otrverwaltung import cutlists
 from otrverwaltung.gui import LoadCutDialog
 from otrverwaltung.actions.cut import Cut
@@ -39,6 +40,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         self.marker_a, self.marker_b = 0, -1
         self.timelines = [ [] ]
         self.cut_selected = -1
+        self.cut_selected_last = -1
         self.timer = None
         self.hide_cuts = False
         self.frames = 0
@@ -52,7 +54,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         self.last_direction = "none"
         self.seek_distance_default = 0
         self.seek_distance = 0
-        self.gst_version = Gst.version()[0] * 100 + Gst.version()[1]
+        # self.gst_version = Gst.version()[0] * 100 + Gst.version()[1]
 
         self.state = Gst.State.NULL
         self.player = Gst.ElementFactory.make("playbin", "playbin")
@@ -73,26 +75,23 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         bus.enable_sync_message_emission()
         bus.connect("sync-message::element", self.on_sync_message)
         bus.connect("message", self.on_message)
-        
 
     def do_parser_finished(self, builder):
+        self.log.debug("funtion start")
         self.builder = builder
         self.builder.connect_signals(self)
         self.slider = self.builder.get_object('slider')
         self.slider.set_digits(0)
-        # TODO: make slider.set_draw_value an option
-        #       needs formatting: offset to the right at start position, to the left at end
-        #self.slider.set_draw_value(True)
+        self.slider.set_draw_value(False)
 
         self.movie_window = self.builder.get_object('movie_window')
         self.movie_window.connect('realize', self.on_realize)
         self.movie_window.connect('unrealize', self.on_unrealize)
 
-
         self.hide_cuts = self.builder.get_object('checkbutton_hide_cuts').get_active()
 
-        cutslistmodel = self.builder.get_object('cutslist')
-        #cutslistmodel.set_default_sort_func(None)
+        self.cutslistmodel = self.builder.get_object('cutslist')
+        #cutslistmodel.set_default_sort_func(None) # Throws error 1st argument cannot be None
         cutslistselection = self.builder.get_object('cutsview').get_selection()
         cutslistselection.connect('changed', self.on_cuts_selection_changed)
 
@@ -106,6 +105,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
     def on_realize(self, widget, data=None):
         self.log.debug ("function start")
+
         window = widget.get_window()
         # xid must be retrieved first in GUI-thread and before creating player to
         # prevent racing conditions. You need to get the XID after window.show_all().
@@ -116,6 +116,11 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         # it to the video sink
         self.player.set_window_handle(self.xid)
 
+        # movie_window_width = self.movie_window.get_allocated_width()
+        # movie_window_height = int(movie_window_width / (16/9))
+        # self.log.error("movie_window size: {0} x {1}".format(movie_window_width, movie_window_height))
+        # self.movie_window.set_size_request(movie_window_width, movie_window_height)
+
         self.ready_callback()
 
     def on_unrealize(self,widget,data=None):
@@ -125,7 +130,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
     def get_cuts_in_frames(self, cuts, in_frames):
         if cuts == []:
             res = [(0, self.frames)]
-            self.log.debug("Framelist: {0}".format(self.frames))
+            self.log.debug("Framelist: {}".format(self.frames))
         elif in_frames:
             res = cuts
         else:
@@ -133,8 +138,8 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
             for start, duration in cuts:
                 start_frame = int(start * self.framerate_num / self.framerate_denom)
                 duration_frames = int(duration * self.framerate_num / self.framerate_denom)
-                self.log.debug("Startframe = {0}".format(start_frame))
-                self.log.debug("Duration = {0}".format(duration_frames))
+                self.log.debug("Startframe = {}".format(start_frame))
+                self.log.debug("Duration = {}".format(duration_frames))
                 res.append((start_frame,duration_frames))
         return res
 
@@ -168,6 +173,9 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         return cutlist
 
     def set_cuts(self, cutlist, cuts):
+        self.log.debug("Function start")
+        self.log.debug("var cutlist: {}".format(cutlist))
+        self.log.debug("var cuts: {}".format(cuts))
         cutlist.fps = float(self.framerate_num) / float(self.framerate_denom)
         cutlist.cuts_frames = cuts
         cutlist.cuts_seconds = []
@@ -186,13 +194,27 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
         self.seek_distance_default = self.config.get('general', 'seek_distance_default')
         self.seek_distance = self.seek_distance_default
+        self.atfc = self.config.get('general', 'alt_time_frame_conv')
+
+        # TESTING_ACTIVE
+        if self.atfc:
+            self.frame_timecode, self.timecode_frame, error = self.get_timecodes_from_file(self.filename)
+            if self.frame_timecode is None:
+                self.log.warning("Error: Timecodes konnten nicht ausgelesen werden.")
+        # TESTING_ACTIVE
 
         self.keyframes, error = self.get_keyframes_from_file(self.filename)
-        if self.keyframes == None:
+        if self.keyframes is None:
             self.log.warning("Error: Keyframes konnten nicht ausgelesen werden.")
 
-        self.movie_window.set_size_request(self.config.get('general', 'cutinterface_resolution_x'),\
-                                           self.config.get('general', 'cutinterface_resolution_y'))
+        
+
+        self.movie_window.set_size_request(self.config.get('general', 'cutinterface_resolution_x'),
+                                             self.config.get('general', 'cutinterface_resolution_y'))
+        # Make window a bit bigger than natural size to avoid size changes
+        ci_window = self.builder.get_object('cutinterface_dialog')
+        ci_window_size_request_width = ci_window.size_request().width
+        ci_window.set_size_request(int(ci_window.size_request().width * 1.05), int(ci_window.size_request().height * 1.05))
 
         self.hide_cuts = self.config.get('general', 'cutinterface_hide_cuts')
 
@@ -210,8 +232,8 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         self.log.debug("framerate_num: {}".format(self.framerate_num))
         self.log.debug("framerate_denom: {}".format(self.framerate_denom))
         self.videolength = self.d.get_duration()
-        self.frames = self.videolength * self.framerate_num / self.framerate_denom / Gst.SECOND  # ROUND
-        self.timelines = [self.get_cuts_in_frames(self.initial_cutlist, 
+        self.frames = round(self.videolength * self.framerate_num / self.framerate_denom / Gst.SECOND)  # ROUND
+        self.timelines = [self.get_cuts_in_frames(self.initial_cutlist,
                                                   self.initial_cutlist_in_frames)]
 
         # Set player uri only after discoverer is done
@@ -234,7 +256,8 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
     def ready_callback(self):
         self.log.debug("Function start")
         self.builder.get_object('label_filename').\
-            set_markup("Aktuelle Datei: <b>%s</b>" % os.path.basename(self.filename))
+            set_markup("Aktuelle Datei: <b>%s</b>" %
+            os.path.basename(self.filename))
 
         self.update_timeline()
         self.update_listview()
@@ -242,26 +265,34 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         self.timer = GObject.timeout_add(200, self.tick)
 
     def tick(self):
+        # self.log.debug("Function start")
+
+        # if inspect not in dir():  # this may result in false positives
+            # import inspect
+        # current_frame = inspect.currentframe()
+        # caller_frame = inspect.getouterframes(curframe, 2)
+        # self.log.debug("Caller: {}".format(caller_frame[1][3]))
+
         self.update_frames_and_time()
         self.update_slider()
         self.builder.get_object('checkbutton_hide_cuts').set_active(self.hide_cuts)
         return self.timeoutcontrol
 
     def set_marker(self, a=None, b=None):
-        """ Set markers a and/or b to a specific frame posititon and update the buttons """
+        """ Set markers a and/or b to a specific frame position and update the buttons """
 
         if a is not None:
             self.marker_a = a
-            
+
             if a != -1 and self.marker_b < 0:
                     self.marker_b = self.get_frames()-1
-    
+
         if b is not None:
             self.marker_b = b
-            
+
             if b != -1 and self.marker_a < 0:
                     self.marker_a = 0
-        
+
         if self.marker_a != -1 and self.marker_b != -1 and self.marker_a > self.marker_b:
             self.log.debug("Switch a and b")
             c = self.marker_b
@@ -272,7 +303,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
             self.builder.get_object('button_jump_to_marker_a').set_label('-')
         else:
             self.builder.get_object('button_jump_to_marker_a').set_label(str(int(self.marker_a)))
-        
+
         if self.marker_b == -1:
             self.builder.get_object('button_jump_to_marker_b').set_label('-')
         else:
@@ -369,7 +400,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
     def remove_segment(self, rel_s, rel_d):
         self.log.debug("\n\033[1;31m-- Entering remove_segment\033[1;m")
-        self.log.debug("Current timeline is: {0}".format(self.timelines[-1]))
+        self.log.debug("Current timeline is: {}".format(self.timelines[-1]))
 
         abs_start = self.get_absolute_position(rel_s)
         abs_end = self.get_absolute_position(rel_s + rel_d - 1)
@@ -378,7 +409,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         inverted_timeline.append((abs_start, abs_end - abs_start + 1))
         self.timelines.append(self.invert_full(inverted_timeline))
 
-        self.log.debug("Current timeline is: {0}".format(self.timelines[-1]))
+        self.log.debug("Current timeline is: {}".format(self.timelines[-1]))
         self.log.debug("\033[1;31m-- Leaving remove_segment\033[1;m\n")
 
         self.update_timeline()
@@ -386,10 +417,10 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
         time.sleep(0.2)
         if self.hide_cuts:
-            self.log.debug("Seek To: {0}".format(rel_s))
+            self.log.debug("Seek To: {}".format(rel_s))
             self.jump_to(frames=rel_s)
         else:
-            self.log.debug("Seek To: {0}".format(abs_end + 1))
+            self.log.debug("Seek To: {}".format(abs_end + 1))
             self.jump_to(frames=abs_end+1)
 
     def get_frames(self):
@@ -401,22 +432,38 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
         return frames
 
+    def query_position(self, gst_format):
+        for count in range(2):
+            success, cur_pos = self.player.query_position(gst_format)
+            if success:
+                break
+            else:
+                time.sleep(0.05)
+        return success, cur_pos
+
     def update_frames_and_time(self):
         try:
-            current_position = self.player.query_position(Gst.Format.TIME)[1]
+            # current_position = self.player.query_position(Gst.Format.TIME)[1]
+            success, current_position = self.query_position(Gst.Format.TIME)
             duration = self.player.query_duration(Gst.Format.TIME)[1]
+            if not success:
+                raise ValueError('query_position() was not successful')
         except Exception as e:  # manchmal geht es nicht, bspw. wenn gerade erst geseekt wurde
             self.log.warning("Exception: {}".format(e))
             return
 
-        self.current_frame_position = current_position * self.framerate_num / self.framerate_denom / Gst.SECOND  # ROUND
-
-        if self.keyframes != None and self.current_frame_position in self.keyframes :
-            self.builder.get_object('label_time').set_text('Frame(K): %i/%i, Zeit %s/%s' % (self.current_frame_position,
-                                    self.get_frames() - 1, self.convert_sec(current_position), self.convert_sec(duration)))
+        if self.atfc:
+            self.current_frame_position = self.time_to_frame(current_position )  # TESTING_ACTIVE
         else:
-            self.builder.get_object('label_time').set_text('Frame: %i/%i, Zeit %s/%s' % (self.current_frame_position,
-                                    self.get_frames() - 1, self.convert_sec(current_position), self.convert_sec(duration)))
+            self.current_frame_position = current_position * self.framerate_num / self.framerate_denom / Gst.SECOND  # ROUND
+
+        # ROUND
+        if self.keyframes != None and round(self.current_frame_position) in self.keyframes:
+            string = 'Frame(K): '
+        else:
+            string = 'Frame: '
+        self.builder.get_object('label_time').set_text(string + '%i/%i, Zeit %s/%s' % (self.current_frame_position,
+                                self.get_frames() - 1, self.convert_sec(current_position), self.convert_sec(duration)))
 
     def update_slider(self):
         try:
@@ -433,7 +480,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         # TODO check port 2.7 to 3.0
         # catch Gst.QueryError
         except TypeError as typeError:
-           pass
+           self.log.info("Exeption: {}".format(typeError))
 
     def seeker(self, direction):
         """ Jump forward or backward by self.seek_distance.
@@ -448,7 +495,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
                     self.seek_distance = 1
                 self.log.debug("BISECT: direction: {0}, last_direction: {1}, seek_distance: {2}"
                                                 .format(direction, self.last_direction, self.seek_distance))
-            
+
         if direction == 'left':
             self.jump_relative(int(self.seek_distance * -1))
             self.last_direction = direction
@@ -463,33 +510,70 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
     def update_listview(self):
         self.log.debug("Function start")
-        global path
         listview = self.builder.get_object('cutsview')
         listselection = listview.get_selection()
         listmodel, listiter = listselection.get_selected()
         if listiter:
-            path = listmodel.get_path(listiter)
-        listview.set_model(None)                # for speeding up the update of the view
+            tree_path = listmodel.get_path(listiter)
+        listview.set_model(None)  # for speeding up the update of the view
         listmodel.clear()
 
         if not self.getVideoLength:
             inverted = self.invert_simple(self.timelines[-1])
-            # print inverted
             for start, duration in inverted:
                 listmodel.append((start, start + duration - 1))
 
         listview.set_model(listmodel)
         if listiter:
-            listselection.select_path(path)
+            listselection.select_path(tree_path)
 
+    def select_cut(self, direction):
+        listview = self.builder.get_object('cutsview')
+        listselection = listview.get_selection()
+        listmodel, listiter = listselection.get_selected()
+        rows = listmodel.iter_n_children(None)
+        if listiter:  # A cut is selected
+            if direction =="next":
+                listiter = listmodel.iter_next(listiter)    
+                if listiter is None:
+                    listiter = listmodel.get_iter_first()
+            elif direction =="prev":
+                listiter = listmodel.iter_previous(listiter)
+                if listiter is None:
+                    # ~ rows = listmodel.iter_n_children(None)
+                    listiter = listmodel.iter_nth_child(None, rows - 1)
+
+            tree_path = listmodel.get_path(listiter)
+            listselection.select_path(tree_path)
+        else:  # No cut selected
+            if direction == "next":
+                if self.cut_selected_last + 1:  # same as if not self.cut_selected_last == -1
+                    listiter = listmodel.iter_nth_child(None, self.cut_selected_last + 1)
+                    if listiter is None:
+                        listiter = listmodel.get_iter_first()
+                else:
+                    listiter = listmodel.get_iter_first()
+            elif direction == "prev":
+                if self.cut_selected_last + 1:  # same as if not self.cut_selected_last == -1
+                    listiter = listmodel.iter_nth_child(None, self.cut_selected_last + 1)
+                    if listiter is None:
+                        # ~ rows = listmodel.iter_n_children(None)
+                        listiter = listmodel.iter_nth_child(None, rows - 1)
+                else:
+                    # ~ rows = listmodel.iter_n_children(None)
+                    listiter = listmodel.iter_nth_child(None, rows - 1)
+
+            tree_path = listmodel.get_path(listiter)
+            listselection.select_path(tree_path)
+            
     def is_remove_modus(self):
         return self.cut_selected < 0 or self.hide_cuts
 
     def update_remove_button(self):
         if self.is_remove_modus():
-            self.builder.get_object('button_remove').set_label('Bereich entfernen')
+            self.builder.get_object('button_remove').set_label('Entfernen')
         else:
-            self.builder.get_object('button_remove').set_label('Veränderung übernehmen')
+            self.builder.get_object('button_remove').set_label('Übernehmen')
 
     def convert_sec(self, time):
         s, rest = divmod(time, Gst.SECOND)
@@ -530,25 +614,25 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
                 self.getVideoLength = not self.getVideoLength
                 self.log.debug("Async done")
                 self.videolength = self.player.query_duration(Gst.Format.TIME)
-                self.frames = self.videolength[1] * self.framerate_num / self.framerate_denom / Gst.SECOND  # ROUND
+                self.frames = round(self.videolength[1] * self.framerate_num / self.framerate_denom / Gst.SECOND)  # ROUND
                 self.slider.set_range(0, self.get_frames())
                 self.timelines = [self.get_cuts_in_frames(self.initial_cutlist, self.initial_cutlist_in_frames)]
                 self.builder.get_object('slider').set_range(0, self.get_frames())
                 self.slider.queue_draw()
-                self.log.debug("Timelines: {0}".format(self.timelines))
-                self.log.debug("framerate_num: {0}".format(self.framerate_num))
-                self.log.debug("framerate_denom: {0}".format(self.framerate_denom))
-                self.log.debug("videolength: {0}".format(self.videolength))
-                self.log.debug("frames: {0}".format(self.frames))
+                self.log.debug("Timelines: {}".format(self.timelines))
+                self.log.debug("framerate_num: {}".format(self.framerate_num))
+                self.log.debug("framerate_denom: {}".format(self.framerate_denom))
+                self.log.debug("videolength: {}".format(self.videolength))
+                self.log.debug("Number of frames: {}".format(self.frames))
 
     # signals #
 
     def on_draw_movie_window(self, widget, cr):
         """
-        this function is called every time the video window needs to be
+        This function is called every time the video window needs to be
         redrawn. GStreamer takes care of this in the PAUSED and PLAYING states.
         in the other states we simply draw a black rectangle to avoid
-        any garbage showing up
+        any garbage showing up.
         """
         if self.state < Gst.State.PAUSED:
             allocation = widget.get_allocation()
@@ -559,28 +643,48 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         return False
 
     def on_window_key_press_event(self, widget, event, *args):
-        """ handle keyboard events """
+        """handle keyboard events"""
         keyname = Gdk.keyval_name(event.keyval).upper()
         mod_ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK)
         mod_shift = (event.state & Gdk.ModifierType.SHIFT_MASK)
+        mod_alt = (event.state & Gdk.ModifierType.MOD1_MASK)
 
         if event.type == Gdk.EventType.KEY_PRESS:
-            # CONTROL
-            if not mod_shift and mod_ctrl:
+            time.sleep(0.05)
+            # CTRL
+            if not mod_shift and not mod_alt and mod_ctrl:
                 if keyname == 'LEFT':
                     self.seeker("left")
-                    time.sleep(0.05)
                     return True
                 if keyname == 'RIGHT':
                     self.seeker("right")
-                    time.sleep(0.05)
                     return True
                 if keyname == 'DOWN':
                     self.seeker("reset")
-                    time.sleep(0.05)
                     return True
-            # Not shift, not ctrl
-            if not mod_ctrl and not mod_shift:
+                if keyname == 'DOWN':
+                    self.seeker("reset")
+                    return True
+            # SHIFT
+            if not mod_ctrl and not mod_alt and mod_shift:
+                if keyname == 'LEFT':
+                    # -10 frames
+                    self.on_button_fast_back_clicked(None)
+                    return True
+                elif keyname == 'RIGHT':
+                    # +10 frames
+                    self.on_button_fast_forward_clicked(None)
+                    return True
+                elif keyname == 'UP':
+                    # +100 frames
+                    self.on_button_ffast_forward_clicked(None)
+                    return True
+                elif keyname == 'DOWN':
+                    # -100 frames
+                    self.on_button_ffast_back_clicked(None)
+                    return True
+            # Not SHIFT, not CTRL, not ALT
+            if not mod_ctrl and not mod_shift and not mod_alt:
                 if keyname == 'LEFT':
                     return True
                 elif keyname == 'RIGHT':
@@ -610,23 +714,27 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
                     self.on_load_button_clicked(None)
                     return True
                 elif keyname == 'SPACE':
-                    if self.is_playing:
-                        self.on_button_pause_clicked(None)
-                    else:
-                        self.on_button_play_clicked(None)
+                    self.on_button_play_pause_clicked(self.builder.get_object('button_play'))
                     return True
-            else:
-                self.log.debug("keyname: {0}".format(keyname))
+                elif keyname == 'N':
+                    self.select_cut('next')
+                    return True
+                elif keyname == 'B':
+                    self.select_cut('prev')
+                    return True
+                else:
+                    self.log.warn("keyname: {}".format(keyname))
 
         return False
 
     def on_window_key_release_event(self, widget, event, *args):
-        """ handle keyboard events """
+        """handle keyboard events"""
         keyname = Gdk.keyval_name(event.keyval).upper()
         mod_ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK)
         mod_shift = (event.state & Gdk.ModifierType.SHIFT_MASK)
         if not mod_ctrl and not mod_shift:
             if event.type == Gdk.EventType.KEY_RELEASE:
+                time.sleep(0.05)
                 if keyname == 'LEFT':
                     self.on_button_back_clicked(None)
                     return True
@@ -642,7 +750,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
     def on_slider_value_changed(self, slider):
         frames = slider.get_value()
-        self.log.debug("Slider value = {0}".format(frames))
+        self.log.debug("Slider value = {}".format(frames))
         if frames >= self.get_frames():
             self.log.debug("slider.get_value() >= self.get_frames(). Restricting.")
             frames = self.get_frames() - 1
@@ -651,32 +759,49 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
             self.log.debug("update_frames_and_time() by slider change")
             self.update_frames_and_time()
 
-    def on_button_play_clicked(self, button, data=None):
-        self.is_playing = True
-        self.player.set_state(Gst.State.PLAYING)
-
-    def on_button_pause_clicked(self, button, data=None):
-        self.is_playing = False
-        self.player.set_state(Gst.State.PAUSED)
-        self.update_frames_and_time()
+    def on_button_play_pause_clicked(self, button, data=None):
+        if self.is_playing:
+            self.is_playing = False
+            self.player.set_state(Gst.State.PAUSED)
+            button.set_label("  Play  ")
+            self.update_frames_and_time()
+        else:
+            self.is_playing = True
+            self.player.set_state(Gst.State.PLAYING)
+            button.set_label("Pause")
 
     def jump_relative(self, frames, flags = Gst.SeekFlags.ACCURATE):
         try:
-            nano_seconds = self.player.query_position(Gst.Format.TIME)[1]
+            success, nano_seconds = self.query_position(Gst.Format.TIME)
+            if not success:
+                raise ValueError('query_position() was not successful') 
         except Exception as e:
-            time.sleep(0.04)
-            nano_seconds = self.player.query_position(Gst.Format.TIME)[1]
+            self.log.debug("Exception: {}".format(e))
+            return
 
         self.videolength = self.player.query_duration(Gst.Format.TIME)[1]
-        self.frames = self.videolength * self.framerate_num / self.framerate_denom / Gst.SECOND  # ROUND
+        self.frames = round(self.videolength * self.framerate_num / self.framerate_denom / Gst.SECOND)  # ROUND
 
-        nano_seconds += frames * (1 * Gst.SECOND * self.framerate_denom / self.framerate_num)
+        if self.atfc:
+            nano_seconds = self.frame_to_time(self.time_to_frame(nano_seconds) + frames)  # TESTING_ACTIVE
+        else:
+            nano_seconds += frames * (1 * Gst.SECOND * self.framerate_denom / self.framerate_num)
+
+        if self.atfc:
+            cond = (self.time_to_frame(nano_seconds) >= self.get_frames())  # TESTING_ACTIVE
+        else:
+            cond = (nano_seconds * self.framerate_num / self.framerate_denom / Gst.SECOND >= self.get_frames())  # ROUND
+
         if nano_seconds < 0:
             self.log.debug("restrict")
             nano_seconds = 0
-        elif nano_seconds * self.framerate_num / self.framerate_denom / Gst.SECOND >= self.get_frames():  # ROUND
+        elif cond:
             self.log.debug("restrict")
-            nano_seconds = (self.get_frames() - 1) * Gst.SECOND * self.framerate_denom / self.framerate_num
+            if self.atfc:
+                nano_seconds = self.frame_to_time(self.get_frames() - 1)  # TESTING_ACTIVE
+            else:
+                nano_seconds = (self.get_frames() - 1) * Gst.SECOND * self.framerate_denom / self.framerate_num
+            
 
         self.jump_to(nanoseconds=nano_seconds, flags=flags)
 
@@ -699,7 +824,10 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
             if frames >= self.get_frames():
                 frames = self.get_frames()-1
 
-            nanoseconds = frames * Gst.SECOND * self.framerate_denom / self.framerate_num
+            if self.atfc:
+                nanoseconds = self.frame_to_time(frames)  # TESTING_ACTIVE
+            else:
+                nanoseconds = frames * Gst.SECOND * self.framerate_denom / self.framerate_num
         elif seconds:
             nanoseconds = seconds * Gst.SECOND
 
@@ -714,14 +842,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         else:
             was_playing = False
 
-        # if self.gst_version < 114:
-        if True:
-            self.jump_key('backward', was_playing)
-        else:
-            # self.jump_to(nanoseconds=self.current_position - 1,
-                    # flags=Gst.SeekFlags.KEY_UNIT | Gst.SeekFlags.SNAP_BEFORE, playing=was_playing)
-            self.jump_to(frames=self.current_frame_position - 1,
-                    flags=Gst.SeekFlags.KEY_UNIT | Gst.SeekFlags.SNAP_BEFORE, playing=was_playing)
+        self.jump_key('backward', was_playing)
 
     def on_button_keyfast_forward_clicked(self, widget, data=None):
         if self.is_playing:
@@ -730,14 +851,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         else:
             was_playing = False
 
-        # if self.gst_version < 114:
-        if True:
-            self.jump_key('forward', was_playing)
-        else:
-            # self.jump_to(nanoseconds=self.current_position + 1,
-                    # flags=Gst.SeekFlags.KEY_UNIT | Gst.SeekFlags.SNAP_AFTER, playing=was_playing)
-            self.jump_to(frames=self.current_frame_position + 1,
-                    flags=Gst.SeekFlags.KEY_UNIT | Gst.SeekFlags.SNAP_AFTER, playing=was_playing)
+        self.jump_key('forward', was_playing)
 
     def on_button_ffast_back_clicked(self, widget, data=None):
         self.jump_relative(-100)
@@ -759,19 +873,20 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
 
     def on_button_a_clicked(self, *args):
         # TODO: warn if Marker A = B or distance between them to low
-        self.log.debug('marker a = {0}'.format(self.current_frame_position))
+        self.log.debug('marker a = {}'.format(self.current_frame_position))
         self.set_marker(a=self.current_frame_position)
         self.slider.queue_draw()
 
     def on_button_b_clicked(self, *args):
         # TODO: warn if Marker A = B or distance between them to low
-        self.log.debug('marker b = {0}'.format(self.current_frame_position))
+        self.log.debug('marker b = {}'.format(self.current_frame_position))
         self.set_marker(b=self.current_frame_position)
         self.slider.queue_draw()
 
     def on_button_remove_clicked(self, widget):
-        self.log.debug("marker a = ".format(self.marker_a))
-        self.log.debug("marker b = ".format(self.marker_b))
+        self.log.debug("Function start")
+        self.log.debug("marker a = {}".format(self.marker_a))
+        self.log.debug("marker b = {}".format(self.marker_b))
         if self.is_remove_modus():
             if self.marker_a >= 0 and self.marker_b >= 0:
                 self.remove_segment(self.marker_a, self.marker_b-self.marker_a+1)
@@ -838,13 +953,15 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
             self.jump_to(frames=pos)
 
     def on_cuts_selection_changed(self, treeselection):
+        self.log.debug("Function start")
         cutslist, cutsiter = treeselection.get_selected()
         button_delete_cut = self.builder.get_object('button_delete_cut')
         button_deselect = self.builder.get_object('button_deselect')
 
         if cutsiter:
             self.cut_selected = cutslist.get_path(cutsiter)[0]
-            self.log.debug("Selected cut = {0}".format(self.cut_selected))
+            self.cut_selected_last = self.cut_selected
+            self.log.debug("Selected cut = {}".format(self.cut_selected))
             a = cutslist.get_value(cutsiter, 0)
             b = cutslist.get_value(cutsiter, 1)
             if self.hide_cuts:
@@ -863,6 +980,7 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
             button_deselect.set_sensitive(False)
 
     def on_button_delete_cut_clicked(self, widget):
+        self.log.debug("Function start")
         global marker_a, marker_b, pos, playing
         if self.hide_cuts:
             playing = self.is_playing
@@ -895,18 +1013,21 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         self.update_listview()
 
     def on_button_deselect_clicked(self, widget):
+        self.log.debug("Function start")
         self.builder.get_object('cutsview').get_selection().unselect_all()
         self.slider.clear_marks()
         self.marker_a = -1
         self.marker_b = -1
 
     def on_button_cut_clicked(self, widget, data=None):
+        self.log.debug("Function start")
         self.buttonOk = True
         self.set_cuts(self.cutlist, self.timelines[-1])
         self.timeoutcontrol = False  # Stops self.timer
         self.close()
 
     def on_button_cancel_clicked(self, widget, data=None):
+        self.log.debug("Function start")
         self.buttonClose = True
         self.set_cuts(self.cutlist, [])
         self.timeoutcontrol = False  # Stops self.timer
@@ -927,11 +1048,11 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
                 # draw only if ...
                 if self.marker_a != self.marker_b and self.marker_a >= 0 and self.marker_b >= 0:
                     self.log.debug("Slider allocation size: {0} x {1}".format(slider.get_allocation().width, slider.get_allocation().height))
-                    self.log.debug("one_frame_in_pixels: {0}".format(one_frame_in_pixels))
+                    self.log.debug("one_frame_in_pixels: {}".format(one_frame_in_pixels))
                     marker_a = border + int(round(self.marker_a * one_frame_in_pixels))
                     marker_b = border + int(round(self.marker_b * one_frame_in_pixels))
 
-                    cr.set_source_rgb(1.0,0.0,0.0)  # red
+                    cr.set_source_rgb(1.0, 0.0, 0.0)  # red
                     cr.rectangle(marker_a, 0, marker_b - marker_a, 5)
                     cr.fill()
 
@@ -940,22 +1061,24 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
                     for start, duration in inverted:
                         pixel_start = border + int(round(start * one_frame_in_pixels))
                         pixel_duration = int(round(duration * one_frame_in_pixels))
-                        
+
                         # draw keyframe cuts that don't need reencoding with a different color
-                        if ((start + duration) in self.keyframes) or (start + duration == self.frames):
-                            cr.set_source_rgb(0.0,0.6,0.0)  # green
+                        # ROUND
+                        if (round(start + duration) in self.keyframes) or (round(start + duration) == self.frames):
+                            cr.set_source_rgb(0.0, 0.6, 0.0)  # green
                         else:
-                            cr.set_source_rgb(1.0,0.6,0.0)  # orange
+                            cr.set_source_rgb(1.0, 0.6, 0.0)  # orange
 
                         cr.rectangle(pixel_start, slider.get_allocation().height - 5, pixel_duration, 5)
                         cr.fill()
 
                 # slider.queue_draw()
             except AttributeError as ex:
-                self.log.warning("Exeption: {0}".format(ex))
+                self.log.warning("Exeption: {}".format(ex))
                 pass
 
     def on_load_button_clicked(self, widget):
+        self.log.debug("Function start")
         load_dialog = LoadCutDialog.NewLoadCutDialog(self.app, self.app.gui)
         load_dialog.set_transient_for(self)
         load_dialog.set_modal(True)
@@ -976,10 +1099,9 @@ class CutinterfaceDialog(Gtk.Dialog, Gtk.Buildable, Cut):
         pass
 
 def NewCutinterfaceDialog():
-    glade_filename = path.getdatapath('ui', 'CutinterfaceDialog.glade')
+    glade_filename = otrpath.getdatapath('ui', 'CutinterfaceDialog.glade')
 
     builder = Gtk.Builder()
     builder.add_from_file(glade_filename)
     dialog = builder.get_object("cutinterface_dialog")
     return dialog
-

--- a/otrverwaltung/gui/LoadCutDialog.py
+++ b/otrverwaltung/gui/LoadCutDialog.py
@@ -18,8 +18,7 @@ import gi
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-import os
-import re
+import os, re, logging
 
 from otrverwaltung.constants import Cut_action
 import otrverwaltung.cutlists as cutlists_management
@@ -36,9 +35,11 @@ class LoadCutDialog(Gtk.Dialog, Gtk.Buildable):
 
     def __init__(self):
         Gtk.Dialog.__init__(self)
+        self.log = logging.getLogger(self.__class__.__name__)
         self.download_error = False
 
     def do_parser_finished(self, builder):
+        self.log.debug("Function start")
         self.builder = builder
         self.builder.connect_signals(self)
 

--- a/otrverwaltung/gui/MainWindow.py
+++ b/otrverwaltung/gui/MainWindow.py
@@ -617,8 +617,8 @@ class MainWindow(Gtk.Window, Gtk.Buildable):
         about_dialog.set_version(version)
         about_dialog.set_website("http://elbersb.de/otrverwaltung")
         about_dialog.set_comments("Zum Verwalten von Dateien von onlinetvrecorder.com.")
-        about_dialog.set_copyright("Copyright \xc2\xa9 2010 Benjamin Elbers")
-        about_dialog.set_authors(["Benjamin Elbers <elbersb@gmail.com>", "JanS", "monarc99"])
+        about_dialog.set_copyright("Copyright \xc2\xa9 2010 Benjamin Elbers and others")
+        about_dialog.set_authors(["Benjamin Elbers", "JanS", "monarc99", "EinApfelbaum", "Timo08", "gCurse"])
         about_dialog.run()
         about_dialog.destroy()
 

--- a/otrverwaltung/gui/PreferencesWindow.py
+++ b/otrverwaltung/gui/PreferencesWindow.py
@@ -144,6 +144,7 @@ class PreferencesWindow(Gtk.Window, Gtk.Buildable):
         CheckButtonBinding(self.builder.get_object('smkv_normalize'), self.app.config, 'smartmkvmerge',
                            'normalize_audio')
         CheckButtonBinding(self.builder.get_object('smkv_mp4'), self.app.config, 'smartmkvmerge', 'remux_to_mp4')
+        CheckButtonBinding(self.builder.get_object('check_alt_time_frame_conv'), self.app.config, 'general', 'alt_time_frame_conv')
 
         self.app.config.connect('general', 'rename_cut',
                                 lambda value: self.builder.get_object('entry_schema').set_sensitive(value))


### PR DESCRIPTION
This one has occasionally been bothering me for years: When the number of video segments becomes double digit, the files are named wrongly (i.e. 'video_encode-0010.mkv' instead of 'video_encode-010.mkv'). This leads to mkvmerge failing in the final step.
The PR should fix this bug.