### PR TITLE
Uploading multiple cutlists should work. Fixes #51

### DIFF
--- a/data/ui/ConclusionDialog.glade
+++ b/data/ui/ConclusionDialog.glade
@@ -205,6 +205,7 @@
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Dateiname&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="selectable">True</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
@@ -329,23 +330,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="check_delete_uncut">
-                    <property name="label" translatable="yes">Ungeschnittene Datei in den Müll verschieben</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="halign">start</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="_on_check_delete_uncut_toggled" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkBox" id="box_rename">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -355,6 +339,7 @@
                         <property name="width_request">100</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="margin_left">5</property>
                         <property name="label" translatable="yes">&lt;i&gt;Umbenennen:&lt;/i&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
@@ -382,24 +367,6 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkButton" id="button_rename_func">
-                        <property name="can_focus">False</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">reserved for future use	</property>
-                        <property name="always_show_image">True</property>
-                        <signal name="clicked" handler="_on_button_rename_func_clicked" swapped="no"/>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <accelerator key="u" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
@@ -407,34 +374,18 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="box_archive">
+                  <object class="GtkButton" id="button_play">
+                    <property name="label" translatable="yes">Abspielen</property>
+                    <property name="width_request">111</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_bottom">1</property>
-                    <property name="hexpand">True</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkLabel" id="label6">
-                        <property name="width_request">100</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;i&gt;Archivieren:&lt;/i&gt;</property>
-                        <property name="use_markup">True</property>
-                        <property name="xalign">1</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="image">image5</property>
+                    <signal name="clicked" handler="_on_button_play_clicked" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
                   </packing>
                 </child>
                 <child>
@@ -447,9 +398,10 @@
                         <property name="width_request">100</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="margin_left">5</property>
                         <property name="label" translatable="yes">&lt;i&gt;Wertung:&lt;/i&gt;</property>
                         <property name="use_markup">True</property>
-                        <property name="xalign">1</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -481,23 +433,96 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box_archive">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_bottom">1</property>
+                    <property name="hexpand">True</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkLabel" id="label6">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">5</property>
+                        <property name="label" translatable="yes">&lt;i&gt;Archivieren:&lt;/i&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">2</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="button_play">
-                    <property name="label" translatable="yes">Abspielen</property>
-                    <property name="width_request">111</property>
+                  <object class="GtkBox" id="hbox_replace">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="image">image5</property>
-                    <signal name="clicked" handler="_on_button_play_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label_replace">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">5</property>
+                        <property name="label" translatable="yes">&lt;i&gt;Ersetze:             &lt;/i&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_spaces">
+                        <property name="label" translatable="yes">Leerzeichen</property>
+                        <property name="name">button_underscore</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="_on_button_spaces_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_umlauts">
+                        <property name="label" translatable="yes">Umlaute</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="_on_button_umlauts_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
                   </packing>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
                 <child>
                   <placeholder/>
@@ -507,6 +532,23 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="check_delete_uncut">
+                <property name="label" translatable="yes">Ungeschnittene Datei in den Müll verschieben</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="halign">start</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="_on_check_delete_uncut_toggled" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -872,7 +914,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>

--- a/data/ui/CutinterfaceDialog.glade
+++ b/data/ui/CutinterfaceDialog.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.18"/>
   <requires lib="CutinterfaceDialog" version="1.0"/>
   <object class="GtkListStore" id="cutslist">
     <columns>
@@ -73,6 +73,7 @@
                 <property name="can_focus">False</property>
                 <property name="margin_left">10</property>
                 <property name="label" translatable="yes">Datei: </property>
+                <property name="selectable">True</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -518,7 +519,6 @@
                     <property name="can_focus">False</property>
                     <property name="margin_bottom">5</property>
                     <property name="shadow_type">in</property>
-                    <property name="propagate_natural_width">True</property>
                     <child>
                       <object class="GtkTreeView" id="cutsview">
                         <property name="visible">True</property>

--- a/data/ui/LoadCutDialog.glade
+++ b/data/ui/LoadCutDialog.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.12"/>
   <requires lib="LoadCutDialog" version="1.0"/>
   <object class="LoadCutDialog" id="load_cut_dialog">
     <property name="can_focus">False</property>

--- a/otrverwaltung/conclusions.py
+++ b/otrverwaltung/conclusions.py
@@ -17,7 +17,7 @@
 from otrverwaltung.constants import Action
 import os.path
 from os.path import splitext
-import logging
+import logging, time
 
 from otrverwaltung.cutlists import Cutlist
 from otrverwaltung.constants import Action, Status
@@ -172,7 +172,10 @@ class ConclusionsManager:
         def upload():
             error_messages = []
 
+            count = len(cutlists)
+            counter = 0
             for cutlist in cutlists:
+                counter += 1
                 error_message = cutlist.upload(self.app.config.get('general', 'server'),
                                                self.app.config.get('general', 'cutlist_hash'))
                 if error_message:
@@ -180,8 +183,10 @@ class ConclusionsManager:
                 else:
                     if self.app.config.get('general', 'delete_cutlists'):
                         fileoperations.remove_file(cutlist.local_filename)
-
-            count = len(cutlists)
+                self.log.debug("Counter: {}, Count: {}".format(counter, count))
+                if counter < count:
+                    self.log.debug("Multiple cutlists: Next upload delayed.")
+                    time.sleep(1.1)
 
             message = "Es wurden %s/%s Cutlisten hochgeladen!" % (str(count - len(error_messages)), str(count))
             if len(error_messages) > 0:


### PR DESCRIPTION
- CutinterfaceDialog.glade and LoadCutDialog.glade: Gtk version changed for
  Linux Mint
- Filename label in CutinterfaceDialog and ConclusionDialog are now selectable
  so the filname can be copied to clipboard if needed.
- ConclusionDialog: New buttons to replace spaces (-> underscore) and umlauts
  incl. ß (-> ae, ss etc.) in the filename.